### PR TITLE
Updated cipher_suite module

### DIFF
--- a/src/cipher_suite.rs
+++ b/src/cipher_suite.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 pub trait CipherSuite: erased_serde::Serialize {
-    fn hash(&self, buffer: &Vec<u8>) -> Vec<u8>;
+    fn hash(&self, buffer: &[u8]) -> Vec<u8>;
     fn sign(&self, input: &str, output: &str) -> io::Result<()>;
     fn verify(&self, header: &str) -> io::Result<()>;
     fn get_name(&self) -> &String;
@@ -18,21 +18,21 @@ pub trait CipherSuite: erased_serde::Serialize {
 serialize_trait_object!(CipherSuite);
 
 // Sha256 hash function
-fn sha256_hash(buffer: &Vec<u8>) -> Vec<u8> {
+fn sha256_hash(buffer: &[u8]) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(buffer);
     hasher.finalize().to_vec()
 }
 
 // Sha512 hash function
-fn sha512_hash(buffer: &Vec<u8>) -> Vec<u8> {
+fn sha512_hash(buffer: &[u8]) -> Vec<u8> {
     let mut hasher = Sha512::new();
     hasher.update(buffer);
     hasher.finalize().to_vec()
 }
 
 // Blake3 hash function
-fn blake3_hash(buffer: &Vec<u8>) -> Vec<u8> {
+fn blake3_hash(buffer: &[u8]) -> Vec<u8> {
     let mut hasher = blake3::Hasher::new();
     hasher.update(buffer);
     hasher.finalize().to_vec()
@@ -61,7 +61,7 @@ fn quantum_sign(
 
     // Write header contents to signature file
     let mut out_file = OpenOptions::new().append(true).create(true).open(output)?;
-    out_file.write(header_str.as_bytes())?;
+    Write::write_all(&mut out_file, header_str.as_bytes())?;
 
     Ok(())
 }
@@ -116,7 +116,7 @@ impl Dilithium2Sha256 {
 }
 
 impl CipherSuite for Dilithium2Sha256 {
-    fn hash(&self, buffer: &Vec<u8>) -> Vec<u8> {
+    fn hash(&self, buffer: &[u8]) -> Vec<u8> {
         sha256_hash(buffer)
     }
 
@@ -196,7 +196,7 @@ impl Dilithium2Sha512 {
 }
 
 impl CipherSuite for Dilithium2Sha512 {
-    fn hash(&self, buffer: &Vec<u8>) -> Vec<u8> {
+    fn hash(&self, buffer: &[u8]) -> Vec<u8> {
         sha512_hash(buffer)
     }
 
@@ -276,7 +276,7 @@ impl Falcon512Sha256 {
 }
 
 impl CipherSuite for Falcon512Sha256 {
-    fn hash(&self, buffer: &Vec<u8>) -> Vec<u8> {
+    fn hash(&self, buffer: &[u8]) -> Vec<u8> {
         sha256_hash(buffer)
     }
 
@@ -356,7 +356,7 @@ impl Falcon512Sha512 {
 }
 
 impl CipherSuite for Falcon512Sha512 {
-    fn hash(&self, buffer: &Vec<u8>) -> Vec<u8> {
+    fn hash(&self, buffer: &[u8]) -> Vec<u8> {
         sha512_hash(buffer)
     }
 

--- a/src/header.rs
+++ b/src/header.rs
@@ -48,7 +48,7 @@ impl Header {
     }
 
     // Checks if hash of file contents matches expected hash
-    pub fn verify_hash(&self, hash: &Vec<u8>) {
+    pub fn verify_hash(&self, hash: &[u8]) {
         assert!(
             do_vecs_match(hash, &self.file_hash),
             "Verification failed: invalid file contents"
@@ -77,7 +77,7 @@ impl Header {
 }
 
 // Helper function to check if two vectors are equal
-pub fn do_vecs_match<T: PartialEq>(a: &Vec<T>, b: &Vec<T>) -> bool {
+pub fn do_vecs_match<T: PartialEq>(a: &[T], b: &[T]) -> bool {
     let matching = a.iter().zip(b.iter()).filter(|&(a, b)| a == b).count();
     matching == a.len() && matching == b.len()
 }

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -69,12 +69,10 @@ impl Wallet {
                     .expect("Error deserializing ciphersuite");
                 Ok(Box::new(cs))
             }
-            _ => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Unsupported cipher suite id. Enter a value between 1-4",
-                ))
-            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Unsupported cipher suite id. Enter a value between 1-4",
+            )),
         }
     }
 
@@ -111,12 +109,10 @@ impl Wallet {
                 ));
                 self.save_ciphersuite(&name, cs)
             }
-            _ => {
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Unsupported cipher suite id. Enter a value between 1-4",
-                ))
-            }
+            _ => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Unsupported cipher suite id. Enter a value between 1-4",
+            )),
         }
     }
 

--- a/tests/official_test.rs
+++ b/tests/official_test.rs
@@ -2,15 +2,14 @@
 use rust_cli::file_ops::{sign, verify, Header}; // Keep the import as it is
 use rust_cli::persona::Persona;
 use rust_cli::wallet::Wallet;
+use std::convert::TryInto;
 use std::fs;
 use std::time::Instant;
 use tempfile::tempdir;
-use std::convert::TryInto;
 // use crate::persona::{get_hash, get_sig_algorithm}; // Import necessary items from persona module
 // use oqs::sig::{PublicKey, Signature}; // Import necessary items from oqs::sig module
 // use crate::file_ops::{do_vecs_match}; // Import necessary items from file_ops module
 // use sha2::{Digest, Sha256, Sha512};
-
 
 struct CipherSuite {
     cs_id: u32,
@@ -131,10 +130,22 @@ fn test_sign_and_verify_empty_file() {
     let signature_file = dir.path().join("signature_file_empty.txt");
 
     // Sign empty file
-    sign(&persona_name, &file_path.to_str().unwrap(), &signature_file.to_str().unwrap(), &wallet).unwrap();
+    sign(
+        &persona_name,
+        &file_path.to_str().unwrap(),
+        &signature_file.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 
     // Verify signature against the empty file
-    verify(&persona_name, &signature_file.to_str().unwrap(), &file_path.to_str().unwrap(), &wallet).unwrap();
+    verify(
+        &persona_name,
+        &signature_file.to_str().unwrap(),
+        &file_path.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -153,10 +164,22 @@ fn test_sign_and_verify_large_file() {
     let signature_file = dir.path().join("signature_file_large.txt");
 
     // Sign large file
-    sign(&persona_name, &file_path.to_str().unwrap(), &signature_file.to_str().unwrap(), &wallet).unwrap();
+    sign(
+        &persona_name,
+        &file_path.to_str().unwrap(),
+        &signature_file.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 
     // Verify signature against the large file
-    verify(&persona_name, &signature_file.to_str().unwrap(), &file_path.to_str().unwrap(), &wallet).unwrap();
+    verify(
+        &persona_name,
+        &signature_file.to_str().unwrap(),
+        &file_path.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -171,7 +194,13 @@ fn test_sign_with_non_existent_persona() {
     let signature_file = dir.path().join("signature_file_non_existent.txt");
 
     // Attempt to sign with a non-existent persona
-    sign(&persona_name, &file_path.to_str().unwrap(), &signature_file.to_str().unwrap(), &wallet).unwrap();
+    sign(
+        &persona_name,
+        &file_path.to_str().unwrap(),
+        &signature_file.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -188,7 +217,13 @@ fn test_verify_with_tampered_signature() {
     wallet.save_persona(persona.clone()).unwrap();
 
     let signature_file = dir.path().join("signature_file_tampered.txt");
-    sign(&persona_name, &file_path.to_str().unwrap(), &signature_file.to_str().unwrap(), &wallet).unwrap();
+    sign(
+        &persona_name,
+        &file_path.to_str().unwrap(),
+        &signature_file.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 
     // Tamper with the signature file
     let mut tampered_signature = fs::read_to_string(&signature_file).unwrap();
@@ -196,7 +231,13 @@ fn test_verify_with_tampered_signature() {
     fs::write(&signature_file, tampered_signature).unwrap();
 
     // Attempt to verify with the tampered signature file
-    verify(&persona_name, &signature_file.to_str().unwrap(), &file_path.to_str().unwrap(), &wallet).unwrap();
+    verify(
+        &persona_name,
+        &signature_file.to_str().unwrap(),
+        &file_path.to_str().unwrap(),
+        &wallet,
+    )
+    .unwrap();
 }
 
 #[test]
@@ -215,16 +256,30 @@ fn test_sign_and_verify_file_with_multiple_signatures() {
         let persona = Persona::new(persona_name.to_string(), *cs_id);
         wallet.save_persona(persona.clone()).unwrap();
 
-        let signature_file = dir.path().join(format!("signature_file_{}.txt", persona_name));
+        let signature_file = dir
+            .path()
+            .join(format!("signature_file_{}.txt", persona_name));
         signature_files.push(signature_file.clone());
 
         // Sign file with each persona
-        sign(&persona_name, &file_path.to_str().unwrap(), &signature_file.to_str().unwrap(), &wallet).unwrap();
+        sign(
+            &persona_name,
+            &file_path.to_str().unwrap(),
+            &signature_file.to_str().unwrap(),
+            &wallet,
+        )
+        .unwrap();
     }
 
     // Verify all signatures against the file
     for (persona_name, signature_file) in persona_names.iter().zip(signature_files.iter()) {
-        verify(&persona_name, &signature_file.to_str().unwrap(), &file_path.to_str().unwrap(), &wallet).unwrap();
+        verify(
+            &persona_name,
+            &signature_file.to_str().unwrap(),
+            &file_path.to_str().unwrap(),
+            &wallet,
+        )
+        .unwrap();
     }
 }
 // -----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Changes:

1) Changed error type of verify from oqs::Error to io::Result<()>
- This allows for any library to create the correct kind of error

2) Created quantum_sign() and quantum_verify
- These functions are a boilerplate implementation for any oqs algorithm to implement signing and verification
- Adding these functions improved code reuse

3) Clippy/format fixes